### PR TITLE
Improve Lighthouse performance score and fix robots.txt

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -8,13 +8,17 @@ import roLocale from '@/locales/ro.json'
 import enLocale from '@/locales/en.json'
 
 const inter = Inter({
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext'],
   variable: '--font-inter',
+  weight: ['400', '600'],
+  display: 'swap',
 })
 
 const playfair = Playfair_Display({
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext'],
   variable: '--font-playfair',
+  weight: ['400', '700'],
+  display: 'swap',
 })
 
 export function generateMetadata({ params }: { params: { locale: string } }): Metadata {
@@ -42,7 +46,7 @@ export function generateMetadata({ params }: { params: { locale: string } }): Me
     openGraph: {
       title: metadata.ogTitle,
       description: metadata.ogDescription,
-      url: 'https://vibe.com',
+      url: 'https://vibefusion.ro',
       siteName: 'Vibe Restaurant | Bar',
       images: [
         {

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,18 +1,45 @@
-import { Navbar } from "@/components/layout/navbar"
-import { Hero } from "@/components/sections/hero"
-import { Welcome } from "@/components/sections/welcome"
-import { TableSetting } from "@/components/sections/table-setting"
-import { TryOurMenu } from "@/components/sections/try-our-menu"
-import { DiscoverVenue } from "@/components/sections/discover-venue"
-import { Footer } from "@/components/layout/footer"
-import { InstagramGallery } from "@/components/sections/instagram-gallery"
+import dynamic from 'next/dynamic'
+import { Navbar } from '@/components/layout/navbar'
+import { Hero } from '@/components/sections/hero'
+import { Footer } from '@/components/layout/footer'
+import { getTranslations } from '@/lib/i18n-server'
+import type { Locale } from '@/lib/i18n'
 
-export default function Home() {
+const Welcome = dynamic(
+  () => import('@/components/sections/welcome').then((mod) => mod.Welcome),
+  { loading: () => <section className="py-8 min-h-[400px]" /> }
+)
+const TryOurMenu = dynamic(
+  () => import('@/components/sections/try-our-menu').then((mod) => mod.TryOurMenu),
+  { loading: () => <section className="py-14 min-h-[400px]" /> }
+)
+const TableSetting = dynamic(
+  () => import('@/components/sections/table-setting').then((mod) => mod.TableSetting),
+  { loading: () => <section className="h-32 md:h-80 lg:h-96" /> }
+)
+const DiscoverVenue = dynamic(
+  () => import('@/components/sections/discover-venue').then((mod) => mod.DiscoverVenue),
+  { loading: () => <section className="py-8 min-h-[400px]" /> }
+)
+const InstagramGallery = dynamic(
+  () => import('@/components/sections/instagram-gallery').then((mod) => mod.InstagramGallery),
+  { loading: () => <section className="py-8 min-h-[400px]" /> }
+)
+
+export default function Home({ params }: { params: { locale: string } }) {
+  const locale = params.locale as Locale
+  const t = getTranslations(locale)
+
   return (
     <>
       <Navbar />
       <main className="min-h-screen">
-        <Hero />
+        <Hero
+          locale={locale}
+          description={t('hero.description')}
+          exploreMenu={t('hero.exploreMenu')}
+          bookTable={t('hero.bookTable')}
+        />
         <Welcome />
         <TryOurMenu />
         <TableSetting />
@@ -22,4 +49,4 @@ export default function Home() {
       <Footer />
     </>
   )
-} 
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&family=Dancing+Script:wght@400;500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -108,11 +107,6 @@ html, body {
 
 .menu-item-image:hover {
   transform: scale(1.05);
-}
-
-/* Custom font classes */
-.font-script {
-  font-family: 'Dancing Script', cursive;
 }
 
 /* Line clamp utilities */

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/admin/', '/api/'],
+    },
+    sitemap: 'https://vibefusion.ro/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next'
+
+const baseUrl = 'https://vibefusion.ro'
+
+const locales = ['ro', 'en'] as const
+const pages = ['', '/menu', '/about', '/contact', '/reservations'] as const
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return locales.flatMap((locale) =>
+    pages.map((page) => ({
+      url: `${baseUrl}/${locale}${page}`,
+      lastModified: new Date(),
+      changeFrequency: page === '' ? 'weekly' : 'monthly',
+      priority: page === '' ? 1 : 0.8,
+    }))
+  )
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -19,9 +19,12 @@ export function Footer() {
               <Image 
                 src="/vibe-logo-white-transparent-bg.png" 
                 alt="Vibe Restaurant | Bar" 
-                width={128}
-                height={128}
+                width={345}
+                height={224}
                 className="h-32 w-auto"
+                loading="lazy"
+                sizes="(max-width: 768px) 200px, 345px"
+                quality={85}
               />
 
             </div>

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -44,9 +44,11 @@ export function Navbar() {
             <Image 
               src="/vibe-logo-white-transparent-bg-simple.png" 
               alt="Vibe Restaurant | Bar" 
-              width={48}
-              height={48}
+              width={161}
+              height={84}
               className="h-12 w-auto"
+              sizes="48px"
+              quality={85}
             />
           </Link>
 

--- a/components/sections/discover-venue.tsx
+++ b/components/sections/discover-venue.tsx
@@ -40,6 +40,9 @@ export function DiscoverVenue() {
                 alt="Vibe restaurant terrace and outdoor seating area"
                 fill
                 className="object-cover"
+                loading="lazy"
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                quality={75}
               />
             </div>
           </div>

--- a/components/sections/hero-video.tsx
+++ b/components/sections/hero-video.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+export function HeroVideo() {
+  const [shouldLoad, setShouldLoad] = useState(false)
+  const desktopRef = useRef<HTMLVideoElement>(null)
+  const mobileRef = useRef<HTMLVideoElement>(null)
+
+  useEffect(() => {
+    const scheduleLoad = () => {
+      if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(() => setShouldLoad(true), { timeout: 4000 })
+      } else {
+        setTimeout(() => setShouldLoad(true), 2500)
+      }
+    }
+
+    if (document.readyState === 'complete') {
+      scheduleLoad()
+      return
+    }
+
+    window.addEventListener('load', scheduleLoad, { once: true })
+    return () => window.removeEventListener('load', scheduleLoad)
+  }, [])
+
+  useEffect(() => {
+    if (!shouldLoad) return
+
+    const playVideo = async (video: HTMLVideoElement | null) => {
+      if (!video) return
+      try {
+        await video.play()
+      } catch {
+        // Autoplay may be blocked until user interaction
+      }
+    }
+
+    void playVideo(desktopRef.current)
+    void playVideo(mobileRef.current)
+  }, [shouldLoad])
+
+  if (!shouldLoad) return null
+
+  return (
+    <div className="absolute inset-0 z-[1] opacity-0 animate-[fadeIn_1s_ease-in-out_forwards]">
+      <video
+        ref={desktopRef}
+        autoPlay
+        muted
+        loop
+        playsInline
+        preload="none"
+        className="hidden md:block w-full h-full object-cover brightness-40"
+        style={{ pointerEvents: 'none' }}
+      >
+        <source src="/images/cluj/video/desktop_video_nigiri.mp4" type="video/mp4" />
+      </video>
+      <video
+        ref={mobileRef}
+        autoPlay
+        muted
+        loop
+        playsInline
+        preload="none"
+        className="md:hidden w-full h-full object-cover brightness-40"
+        style={{ pointerEvents: 'none' }}
+      >
+        <source src="/images/cluj/video/mobile_video.mp4" type="video/mp4" />
+      </video>
+      <div className="absolute inset-0 bg-gradient-to-r from-brand-dark/80 via-brand-dark/70 to-transparent" />
+    </div>
+  )
+}

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -1,140 +1,24 @@
-"use client"
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import type { Locale } from '@/lib/i18n'
 
-import { motion } from "framer-motion"
-import Link from "next/link"
-import Image from "next/image"
-import { Button } from "@/components/ui/button"
-import { useTranslation } from "@/lib/i18n"
-import { useState, useEffect, useRef } from "react"
+const HeroVideo = dynamic(
+  () => import('./hero-video').then((mod) => mod.HeroVideo),
+  { ssr: false }
+)
 
-export function Hero() {
-  const { t } = useTranslation()
-  const [videoLoaded, setVideoLoaded] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
-  const [videoError, setVideoError] = useState(false)
-  const [debugInfo, setDebugInfo] = useState('')
-  const [useYouTube, setUseYouTube] = useState(false)  // Start with local video for debugging
-  const videoRef = useRef<HTMLVideoElement>(null)
-  
-  // Replace these with your actual YouTube video IDs after upload
-  const youtubeVideoIds = {
-    desktop: "YOUR_DESKTOP_VIDEO_ID", // Replace with actual YouTube video ID
-    mobile: "YOUR_MOBILE_VIDEO_ID"   // Replace with actual YouTube video ID
-  }
+interface HeroProps {
+  locale: Locale
+  description: string
+  exploreMenu: string
+  bookTable: string
+}
 
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768)
-    }
-    
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
-    
-    return () => window.removeEventListener('resize', checkMobile)
-  }, [])
-
-  // Intersection observer for mobile autoplay
-  useEffect(() => {
-    if (isMobile && videoRef.current) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting && videoRef.current) {
-              videoRef.current.play().catch(console.error)
-            }
-          })
-        },
-        { threshold: 0.5 }
-      )
-      
-      observer.observe(videoRef.current)
-      
-      return () => observer.disconnect()
-    }
-  }, [isMobile])
-
-  useEffect(() => {
-    const videoSrc = isMobile ? "/images/cluj/video/mobile_video.mp4" : "/images/cluj/video/desktop_video_nigiri.mp4"
-    setDebugInfo(`Loading video: ${videoSrc} | Mobile: ${isMobile}`)
-  }, [isMobile])
-
-  const handleVideoLoad = () => {
-    console.log('Video loaded successfully')
-    setVideoLoaded(true)
-    setDebugInfo(prev => prev + ' | Video Loaded ✓')
-  }
-
-  const handleVideoError = (e: any) => {
-    console.error('Video failed to load:', e)
-    console.log('Video error details:', e.target?.error)
-    setVideoError(true)
-    setDebugInfo(prev => prev + ' | Video Error ✗')
-  }
-
-  const handleVideoCanPlay = () => {
-    console.log('Video can start playing')
-    setDebugInfo(prev => prev + ' | Can Play ✓')
-    
-    // Force play for mobile devices
-    if (videoRef.current) {
-      const playPromise = videoRef.current.play()
-      
-      if (playPromise !== undefined) {
-        playPromise
-          .then(() => {
-            console.log('Autoplay started successfully')
-            setDebugInfo(prev => prev + ' | Autoplay Success ✓')
-          })
-          .catch(error => {
-            console.error('Autoplay failed:', error)
-            setDebugInfo(prev => prev + ' | Autoplay Failed ✗')
-            
-            // For mobile, try to play on first user interaction
-            if (isMobile) {
-              const playOnTouch = () => {
-                if (videoRef.current) {
-                  videoRef.current.play().catch(console.error)
-                }
-                document.removeEventListener('touchstart', playOnTouch)
-                document.removeEventListener('click', playOnTouch)
-              }
-              
-              document.addEventListener('touchstart', playOnTouch, { once: true })
-              document.addEventListener('click', playOnTouch, { once: true })
-            }
-          })
-      }
-    }
-  }
-
-  const handleVideoLoadStart = () => {
-    console.log('Video load started')
-    setDebugInfo(prev => prev + ' | Load Started')
-  }
-
-  const handleVideoLoadedMetadata = () => {
-    console.log('Video metadata loaded')
-    setDebugInfo(prev => prev + ' | Metadata ✓')
-  }
-
-  const handleVideoPlaying = () => {
-    console.log('Video is playing')
-    setDebugInfo(prev => prev + ' | Playing ✓')
-  }
-
-  const handleVideoWaiting = () => {
-    console.log('Video is waiting/buffering')
-    setDebugInfo(prev => prev + ' | Buffering...')
-  }
-
-  const handleVideoStalled = () => {
-    console.log('Video stalled')
-    setDebugInfo(prev => prev + ' | Stalled ✗')
-  }
-
+export function Hero({ locale, description, exploreMenu, bookTable }: HeroProps) {
   return (
     <section className="relative h-screen flex items-center justify-center overflow-hidden">
-      {/* Background Image - Always present as fallback */}
       <div className="absolute inset-0 z-0">
         <Image
           src="/restaurant/vibe-restaurant-terrace.jpg"
@@ -142,123 +26,45 @@ export function Hero() {
           fill
           className="object-cover brightness-40"
           priority
+          fetchPriority="high"
+          sizes="100vw"
+          quality={75}
         />
         <div className="absolute inset-0 bg-gradient-to-r from-brand-dark/80 via-brand-dark/70 to-transparent" />
       </div>
 
-      {/* Background Video */}
-      <div className={`absolute inset-0 z-[1] transition-opacity duration-1000 opacity-100'`}>
-        {useYouTube && youtubeVideoIds.desktop !== "YOUR_DESKTOP_VIDEO_ID" ? (
-          // YouTube Embed
-          <div className="w-full h-full relative">
-            <iframe
-              src={`https://www.youtube.com/embed/${isMobile ? youtubeVideoIds.mobile : youtubeVideoIds.desktop}?autoplay=1&mute=1&loop=1&controls=0&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1&playsinline=1&playlist=${isMobile ? youtubeVideoIds.mobile : youtubeVideoIds.desktop}`}
-              className="w-full h-full object-cover brightness-40"
-              style={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                width: '100vw',
-                height: '56.25vw', // 16:9 aspect ratio
-                minHeight: '100vh',
-                minWidth: '177.77vh', // 16:9 aspect ratio
-                transform: 'translate(-50%, -50%)',
-              }}
-              frameBorder="0"
-              allow="autoplay; encrypted-media"
-              allowFullScreen
-              onLoad={() => {
-                setVideoLoaded(true)
-                setDebugInfo(prev => prev + ' | YouTube Loaded ✓')
-              }}
-              onError={() => {
-                setVideoError(true)
-                setUseYouTube(false) // Fallback to local video
-                setDebugInfo(prev => prev + ' | YouTube Error, switching to local ✗')
-              }}
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-brand-dark/80 via-brand-dark/70 to-transparent" />
-          </div>
-        ) : (
-          // Local Video Fallback
-          <>
-            <video
-              key={isMobile ? 'mobile' : 'desktop'}
-              ref={videoRef}
-              autoPlay
-              muted
-              loop
-              playsInline
-              controls={false}
-              disablePictureInPicture
-              disableRemotePlayback
-              webkit-playsinline="true"
-              x5-playsinline="true"
-              x5-video-player-type="h5"
-              className="w-full h-full object-cover brightness-40"
-              style={{ 
-                pointerEvents: 'none',
-                objectFit: 'cover'
-              }}
-              onLoadedData={handleVideoLoad}
-              onLoadedMetadata={handleVideoLoadedMetadata}
-              onCanPlay={handleVideoCanPlay}
-              onPlaying={handleVideoPlaying}
-              onWaiting={handleVideoWaiting}
-              onStalled={handleVideoStalled}
-              onLoadStart={handleVideoLoadStart}
-              onError={handleVideoError}
-              preload="metadata"
-            >
-              <source 
-                src={isMobile ? "/images/cluj/video/mobile_video.mp4" : "/images/cluj/video/desktop_video_nigiri.mp4"} 
-                type="video/mp4" 
-              />
-              Your browser does not support the video tag.
-            </video>
-            <div className="absolute inset-0 bg-gradient-to-r from-brand-dark/80 via-brand-dark/70 to-transparent" />
-          </>
-        )}
-      </div>
+      <HeroVideo />
 
-      {/* Content */}
-      <div className="relative z-10 text-center text-white max-w-6xl mx-auto px-4">
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-          className="space-y-6"
-        >
+      <div className="relative z-10 text-center text-white max-w-6xl mx-auto px-4 animate-fade-in">
+        <div className="space-y-6">
           <div className="mb-8">
             <div className="px-8 py-6 rounded-lg inline-block">
-              <Image 
-                src="/vibe-logo-white-transparent-bg.png" 
-                alt="Vibe Restaurant | Bar" 
-                width={160}
-                height={160}
+              <Image
+                src="/vibe-logo-white-transparent-bg.png"
+                alt="Vibe Restaurant | Bar"
+                width={320}
+                height={208}
                 className="h-32 md:h-40 w-auto mx-auto drop-shadow-lg"
+                priority
+                sizes="(max-width: 768px) 200px, 320px"
+                quality={85}
               />
             </div>
           </div>
           <h3 className="font-serif text-2xl md:text-3xl text-gray-100 max-w-2xl font-light drop-shadow-xl mx-auto leading-[36px] md:leading-[40px]">
-            {t("hero.description")}
+            {description}
           </h3>
-        </motion.div>
+        </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.6 }}
-          className="gap-4 px-12 mt-4"
-        >
+        <div className="gap-4 px-12 mt-4">
           <Button asChild size="lg" className="text-lg px-8 py-4 mb-4 mt-8 mr-0 md:mr-4">
-            <Link href="/menu">{t("hero.exploreMenu")}</Link>
+            <Link href={`/${locale}/menu`}>{exploreMenu}</Link>
           </Button>
           <Button asChild size="lg" variant="outline" className="text-lg px-8 py-4 mb-4 mt-2 backdrop-blur-sm">
-            <Link href="/reservations">{t("hero.bookTable")}</Link>
+            <Link href={`/${locale}/reservations`}>{bookTable}</Link>
           </Button>
-        </motion.div>
+        </div>
       </div>
     </section>
   )
-} 
+}

--- a/components/sections/instagram-gallery.tsx
+++ b/components/sections/instagram-gallery.tsx
@@ -62,6 +62,7 @@ function ImageItem({ image, index }: ImageItemProps) {
         onLoad={() => setIsLoaded(true)}
         loading="lazy"
         sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+        quality={70}
       />
       
       {/* Hover overlay */}

--- a/components/sections/table-setting.tsx
+++ b/components/sections/table-setting.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState, useRef } from "react"
+import Image from "next/image"
 
 export function TableSetting() {
   const [backgroundPosition, setBackgroundPosition] = useState(50)
@@ -11,28 +12,21 @@ export function TableSetting() {
   useEffect(() => {
     const handleScroll = () => {
       if (!containerRef.current) return
-      
+
       const rect = containerRef.current.getBoundingClientRect()
       const windowHeight = window.innerHeight
-      
-      // Calculate how much of the element is visible and its position
       const elementTop = rect.top
       const elementHeight = rect.height
-      
-      // Calculate parallax offset based on element position relative to viewport
       const scrollProgress = (windowHeight - elementTop) / (windowHeight + elementHeight)
-      
-      // Convert to background position percentage (0% to 100%)
       const bgPosition = Math.max(0, Math.min(100, scrollProgress * 40))
-      
+
       setTargetPosition(bgPosition)
     }
 
-    // Smooth animation function
     const animate = () => {
-      setBackgroundPosition(prev => {
+      setBackgroundPosition((prev) => {
         const diff = targetPosition - prev
-        const easing = diff * 0.05 // Adjust this value for smoother/faster animation (0.01 = very smooth, 0.1 = faster)
+        const easing = diff * 0.05
         return prev + easing
       })
       animationFrameRef.current = requestAnimationFrame(animate)
@@ -40,10 +34,8 @@ export function TableSetting() {
 
     window.addEventListener('scroll', handleScroll, { passive: true })
     handleScroll()
-    
-    // Start smooth animation
     animationFrameRef.current = requestAnimationFrame(animate)
-    
+
     return () => {
       window.removeEventListener('scroll', handleScroll)
       if (animationFrameRef.current) {
@@ -54,20 +46,18 @@ export function TableSetting() {
 
   return (
     <section ref={containerRef} className="relative h-32 md:h-80 lg:h-96 overflow-hidden">
-      {/* Background image with parallax */}
-      <div 
-        className="absolute inset-0 w-full h-full"
-        style={{
-          backgroundImage: 'url(/images/hero/2.jpg)',
-          backgroundSize: 'cover',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: `center ${backgroundPosition}%`,
-          willChange: 'background-position'
-        }}
+      <Image
+        src="/images/hero/2.jpg"
+        alt=""
+        fill
+        className="object-cover"
+        loading="lazy"
+        sizes="100vw"
+        quality={70}
+        style={{ objectPosition: `center ${backgroundPosition}%` }}
+        aria-hidden
       />
-      
-      {/* Overlay */}
       <div className="absolute inset-0 bg-black/20 pointer-events-none" />
     </section>
   )
-} 
+}

--- a/components/sections/try-our-menu.tsx
+++ b/components/sections/try-our-menu.tsx
@@ -21,6 +21,9 @@ export function TryOurMenu() {
                 alt="Delicious coffee and menu items at Vibe"
                 fill
                 className="object-cover"
+                loading="lazy"
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                quality={75}
               />
             </div>
           </div>

--- a/components/sections/welcome.tsx
+++ b/components/sections/welcome.tsx
@@ -32,6 +32,9 @@ export function Welcome() {
                 alt="Elegant Vibe restaurant table setting"
                 fill
                 className="object-cover"
+                loading="lazy"
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                quality={75}
               />
             </div>
           </div>

--- a/lib/i18n-server.ts
+++ b/lib/i18n-server.ts
@@ -1,0 +1,24 @@
+type Locale = 'ro' | 'en'
+
+import roLocale from '@/locales/ro.json'
+import enLocale from '@/locales/en.json'
+
+const translations: Record<Locale, typeof roLocale> = {
+  ro: roLocale,
+  en: enLocale,
+}
+
+export function getTranslation(locale: Locale, key: string): string {
+  const keys = key.split('.')
+  let value: unknown = translations[locale]
+
+  for (const k of keys) {
+    value = (value as Record<string, unknown>)?.[k]
+  }
+
+  return typeof value === 'string' ? value : key
+}
+
+export function getTranslations(locale: Locale) {
+  return (key: string) => getTranslation(locale, key)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,24 +1,26 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['instagram.com'],
-    unoptimized: true,
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    minimumCacheTTL: 60 * 60 * 24 * 30,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'instagram.com',
+      },
+    ],
   },
   experimental: {
     outputFileTracingExcludes: {
       '*': [
         'node_modules/@swc/core-linux-x64-gnu',
-        'node_modules/@swc/core-linux-x64-musl', 
+        'node_modules/@swc/core-linux-x64-musl',
         'node_modules/@esbuild/linux-x64',
       ],
     },
   },
-  // For static export (REMOVES server features)
-  // output: 'export',
-  // trailingSlash: true,
-  // images: {
-  //   unoptimized: true
-  // }
 }
 
-module.exports = nextConfig 
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "vibe-fusion-restaurant",
   "version": "0.1.0",
   "private": true,
+  "browserslist": [
+    "chrome >= 87",
+    "firefox >= 78",
+    "safari >= 14",
+    "edge >= 88"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -79,9 +79,8 @@ module.exports = {
         "accordion-up": "accordion-up 0.2s ease-out",
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
-        serif: ['Playfair Display', 'serif'],
-        script: ['Dancing Script', 'cursive'],
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+        serif: ['var(--font-playfair)', 'Georgia', 'serif'],
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,8 +145,15 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-win32-x64-msvc@14.0.4":
+"@next/swc-linux-x64-gnu@14.0.4":
   version "14.0.4"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz"
+  integrity sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==
+
+"@next/swc-linux-x64-musl@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz"
+  integrity sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -521,9 +528,6 @@
 
 "@ungap/structured-clone@^1.2.0":
   version "1.3.0"
-
-"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
-  version "1.11.1"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves Lighthouse performance and fixes the malformed/missing `robots.txt` issue reported in the audit.

## Changes

### SEO
- Add `app/robots.ts` for valid `/robots.txt` crawling rules
- Add `app/sitemap.ts` for `/sitemap.xml` with all locale routes
- Fix Open Graph URL from `vibe.com` → `vibefusion.ro`

### Performance (LCP / FCP)
- **Server-render hero** — eliminates ~2.4s LCP render delay from client-side hydration
- **Defer hero video** — loads after page idle via `requestIdleCallback` instead of competing with LCP (~23MB video payload)
- **Enable Next.js image optimization** — AVIF/WebP conversion, responsive `sizes`, quality tuning
- **Remove render-blocking Google Fonts** `@import` — use `next/font` only
- **Dynamic import** below-fold homepage sections
- **Lazy-load** non-critical images with proper `sizes` attributes
- Replace CSS `background-image` in table-setting with optimized `next/image`
- Add `browserslist` to reduce legacy JavaScript polyfills

## Expected impact

| Metric | Before | Target |
|--------|--------|--------|
| LCP | 23.3s | < 2.5s |
| FCP | 3.2s | < 1.8s |
| Render-blocking | 1,610ms | ~0ms |
| robots.txt | Missing/malformed | Valid |

## Post-merge notes

For a perfect 100 score, source assets on the server may still need compression:
- Re-encode hero videos (target <2MB mobile, <5MB desktop)
- Convert remaining Instagram JPGs (4–17) to WebP
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80f4f9e5-b0be-496d-91c1-73cb73b3a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80f4f9e5-b0be-496d-91c1-73cb73b3a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

