### PR TITLE
Hotfix: fix 500 error from Server Component dynamic import

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,30 +1,14 @@
-import dynamic from 'next/dynamic'
 import { Navbar } from '@/components/layout/navbar'
 import { Hero } from '@/components/sections/hero'
+import { Welcome } from '@/components/sections/welcome'
+import { TableSetting } from '@/components/sections/table-setting'
+import { TryOurMenu } from '@/components/sections/try-our-menu'
+import { DiscoverVenue } from '@/components/sections/discover-venue'
 import { Footer } from '@/components/layout/footer'
+import { InstagramGallery } from '@/components/sections/instagram-gallery'
 import { getTranslations } from '@/lib/i18n-server'
-import type { Locale } from '@/lib/i18n'
 
-const Welcome = dynamic(
-  () => import('@/components/sections/welcome').then((mod) => mod.Welcome),
-  { loading: () => <section className="py-8 min-h-[400px]" /> }
-)
-const TryOurMenu = dynamic(
-  () => import('@/components/sections/try-our-menu').then((mod) => mod.TryOurMenu),
-  { loading: () => <section className="py-14 min-h-[400px]" /> }
-)
-const TableSetting = dynamic(
-  () => import('@/components/sections/table-setting').then((mod) => mod.TableSetting),
-  { loading: () => <section className="h-32 md:h-80 lg:h-96" /> }
-)
-const DiscoverVenue = dynamic(
-  () => import('@/components/sections/discover-venue').then((mod) => mod.DiscoverVenue),
-  { loading: () => <section className="py-8 min-h-[400px]" /> }
-)
-const InstagramGallery = dynamic(
-  () => import('@/components/sections/instagram-gallery').then((mod) => mod.InstagramGallery),
-  { loading: () => <section className="py-8 min-h-[400px]" /> }
-)
+type Locale = 'ro' | 'en'
 
 export default function Home({ params }: { params: { locale: string } }) {
   const locale = params.locale as Locale

--- a/components/sections/hero-video-wrapper.tsx
+++ b/components/sections/hero-video-wrapper.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { HeroVideo } from './hero-video'
+
+export function HeroVideoWrapper() {
+  return <HeroVideo />
+}

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -1,13 +1,9 @@
-import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import Image from 'next/image'
 import { Button } from '@/components/ui/button'
-import type { Locale } from '@/lib/i18n'
+import { HeroVideoWrapper } from './hero-video-wrapper'
 
-const HeroVideo = dynamic(
-  () => import('./hero-video').then((mod) => mod.HeroVideo),
-  { ssr: false }
-)
+type Locale = 'ro' | 'en'
 
 interface HeroProps {
   locale: Locale
@@ -33,7 +29,7 @@ export function Hero({ locale, description, exploreMenu, bookTable }: HeroProps)
         <div className="absolute inset-0 bg-gradient-to-r from-brand-dark/80 via-brand-dark/70 to-transparent" />
       </div>
 
-      <HeroVideo />
+      <HeroVideoWrapper />
 
       <div className="relative z-10 text-center text-white max-w-6xl mx-auto px-4 animate-fade-in">
         <div className="space-y-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging #2, the site returns **500 Internal Server Error** on `/ro` and other pages.

**Root cause:** `next/dynamic` with `ssr: false` was used inside the server-rendered `Hero` component. This throws `NEXT_DYNAMIC_NO_SSR_CODE` in production — Server Components cannot use `ssr: false`.

## Fix

- Add `hero-video-wrapper.tsx` — a thin `"use client"` wrapper for the deferred video
- Import the wrapper directly in `hero.tsx` instead of `dynamic(..., { ssr: false })`
- Revert `page.tsx` to direct imports for below-fold sections (dynamic imports were also failing in production)

## Verified

Production build tested locally: `GET /ro` returns **HTTP 200** with no RSC digest errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80f4f9e5-b0be-496d-91c1-73cb73b3a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80f4f9e5-b0be-496d-91c1-73cb73b3a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

