### PR TITLE
Hotfix: Fix 500 error from dynamic imports in Server Component

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,19 +1,12 @@
-import dynamic from 'next/dynamic'
 import { Navbar } from '@/components/layout/navbar'
 import { Footer } from '@/components/layout/footer'
 import { Hero } from '@/components/sections/hero'
 import { Welcome } from '@/components/sections/welcome'
 import { TryOurMenu } from '@/components/sections/try-our-menu'
 import { DiscoverVenue } from '@/components/sections/discover-venue'
+import { TableSetting } from '@/components/sections/table-setting'
+import { InstagramGallery } from '@/components/sections/instagram-gallery'
 import { getTranslations } from '@/lib/i18n-server'
-
-const TableSetting = dynamic(() =>
-  import('@/components/sections/table-setting').then((mod) => mod.TableSetting)
-)
-
-const InstagramGallery = dynamic(() =>
-  import('@/components/sections/instagram-gallery').then((mod) => mod.InstagramGallery)
-)
 
 type Locale = 'ro' | 'en'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Urgent hotfix — site returning 500

### Root cause

PR #6 used `next/dynamic()` inside `app/[locale]/page.tsx`, which is a **Server Component**. In the App Router, `next/dynamic` is only supported inside Client Components (`"use client"`). Using it in a Server Component causes RSC render failures in production.

The failing components were:
- `TableSetting` (digest error in RSC stream)
- `InstagramGallery` (digest error in RSC stream)

This is the same class of bug fixed in PR #3 (`remove ssr:false dynamic import from Server Component`).

### Fix

Replace `dynamic()` imports with direct imports of the client components. Server Components can import Client Components directly — Next.js creates the client boundary automatically.

```tsx
// Before (broken in production)
const TableSetting = dynamic(() => import('...'))

// After (works)
import { TableSetting } from '@/components/sections/table-setting'
```

### Verified

- `yarn build` passes
- `yarn start` + `curl http://localhost:3000/ro` → **200** (was 500)
- No `__next_error__` or digest errors in RSC payload

### After merge

Deploy immediately — the site is currently down on production.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a35ec06a-8447-4ed8-9f0a-1a66b4cf4cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a35ec06a-8447-4ed8-9f0a-1a66b4cf4cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

